### PR TITLE
Simplify flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,26 +13,16 @@
           inherit system;
           config = { allowUnfree = true; };
         };
+        inherit (pkgs.nodePackages) prettier;
       in
       {
-        # nix run
-        apps = {
-          default = {
-            type = "app";
-            program = "${pkgs.nodePackages.prettier}/bin/prettier";
-          };
-        };
-
-        # nix shell
-        packages.default = pkgs.buildEnv {
-          name = "prettier-dev";
-          paths = [ pkgs.nodePackages.prettier ];
-        };
+        # nix shell and nix run
+        packages.default = prettier;
 
         # nix develop
         devShells.default = pkgs.mkShellNoCC {
           name = "prettier-dev";
-          buildInputs = [ pkgs.nodePackages.prettier ];
+          buildInputs = [ prettier ];
         };
       }
     );


### PR DESCRIPTION
This PR simplifies the flake down to the bare minimum. In this case, the `apps` block is unnecessary because `nix run` works with the default package output.

Feel free to reject if you wish 😄